### PR TITLE
Check for filterCategory ID before putting the extra when navigating …

### DIFF
--- a/app/src/main/java/io/connorwyatt/flashcards/activities/FlashcardCardListActivity.java
+++ b/app/src/main/java/io/connorwyatt/flashcards/activities/FlashcardCardListActivity.java
@@ -175,7 +175,7 @@ public class FlashcardCardListActivity extends AppCompatActivity {
             extras.putLong(FlashcardDetailsActivity.INTENT_EXTRAS.FLASHCARD_ID, flashcard.getId());
         }
 
-        if (filterCategory != null) {
+        if (filterCategory != null && filterCategory.getId() != null) {
             extras.putLong(FlashcardDetailsActivity.INTENT_EXTRAS.CATEGORY_ID, filterCategory
                     .getId());
         }


### PR DESCRIPTION
…to the FlashcardDetails activity. Closes #95 